### PR TITLE
Update xenium.py, fix problem with hidden files in morphology_foucs direcory

### DIFF
--- a/src/spatialdata_io/readers/xenium.py
+++ b/src/spatialdata_io/readers/xenium.py
@@ -286,7 +286,7 @@ def xenium(
     else:
         if morphology_focus:
             morphology_focus_dir = path / XeniumKeys.MORPHOLOGY_FOCUS_DIR
-            files = {f for f in os.listdir(morphology_focus_dir) if f.endswith(".ome.tif")}
+            files = {f for f in os.listdir(morphology_focus_dir) if f.endswith(".ome.tif") and not f.startswith("._")}
             if len(files) not in [1, 4]:
                 raise ValueError(
                     "Expected 1 (no segmentation kit) or 4 (segmentation kit) files in the morphology focus directory, "


### PR DESCRIPTION
In one Xenium output directory I found these files, I guess one can safely ignore the hidden files starting with `._`?

```
{'morphology_focus_0000.ome.tif', '._morphology_focus_0001.ome.tif', 'morphology_focus_0003.ome.tif', 'morphology_focus_0002.ome.tif', 'morphology_focus_0001.ome.tif', '._morphology_focus_0003.ome.tif', '._morphology_focus_0002.ome.tif', '._morphology_focus_0000.ome.tif'}
```

